### PR TITLE
Fix: Update MySQL connector to address CVE-2023-22102

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,9 +30,9 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.33</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Security Fix

This PR addresses a high-severity security vulnerability (CVE-2023-22102) in the MySQL Connector/J dependency.

### Changes
- Updated from  to 
- Changed the artifact ID to the new official one (mysql-connector-j)

### Security Impact
- Fixes a high-severity vulnerability (CVSS score: 8.4)
- Addresses a potential takeover vulnerability in MySQL Connectors

### References
- [CVE-2023-22102](https://nvd.nist.gov/vuln/detail/CVE-2023-22102)
- [GitHub Advisory](https://github.com/advisories/GHSA-m6vm-37g8-gqvh)